### PR TITLE
Update to Recent version of ddms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - openjdk8
+
 install:
     - true
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,16 @@ apply plugin: 'signing'
 
 repositories {
     mavenCentral()
+    maven {
+	url "https://maven.google.com/"
+    }
 }
 
 dependencies {
  compile 'org.apache.ant:ant:1.9.5'
  compile 'org.apache.ant:ant-junit:1.9.5'
  compile 'junit:junit:4.11'
- compile 'com.android.tools.ddms:ddmlib:22.0'
+ compile 'com.android.tools.ddms:ddmlib:26.5.1'
 
 }
 /*

--- a/src/main/java/de/preusslerpark/android/tools/Converter.java
+++ b/src/main/java/de/preusslerpark/android/tools/Converter.java
@@ -119,8 +119,8 @@ public class Converter {
             }
 
             @Override
-            public void testFailed(TestFailure arg0, TestIdentifier test, String arg2) {
-                System.out.println("testFailed " + arg0 + "/" + arg2);
+            public void testFailed(TestIdentifier test, String arg2) {
+                System.out.println("testFailed " + arg2);
 
                 BufferedReader reader = new BufferedReader(new StringReader(arg2));
                 try {
@@ -150,7 +150,15 @@ public class Converter {
             @Override
             public void testRunStopped(long elapsedTime) {
             }
-
+            
+            @Override
+            public void testIgnored(TestIdentifier test) {
+            }
+            
+            @Override
+            public void testAssumptionFailure(TestIdentifier test, String trace) {
+            }
+            
             @Override
             public void testStarted(final TestIdentifier test) {
                 System.out.println("testStarted " + test.toString());


### PR DESCRIPTION
Converter was not working when newer ddms library was present.
Error I got was:
`java.lang.AbstractMethodError: Method de/preusslerpark/android/tools/Converter$1.testIgnored(Lcom/android/ddmlib/testrunner/TestIdentifier;)V is abstract`


So updated ddms to newer version (primarily to updated method signatures of overridden/abstract method) 

@dpreussler Can you review this PR?